### PR TITLE
fix win32+python27 failure.

### DIFF
--- a/setuptools_scm/utils.py
+++ b/setuptools_scm/utils.py
@@ -1,7 +1,7 @@
 """
 utils
 """
-from __future__ import print_function, unicode_literals
+from __future__ import print_function
 import sys
 import shlex
 import subprocess

--- a/testing/test_basic_api.py
+++ b/testing/test_basic_api.py
@@ -173,7 +173,7 @@ def test_root_parameter_creation(monkeypatch):
 
 def test_root_parameter_pass_by(monkeypatch):
     def assert_root_tmp(root):
-        assert root == '/tmp'
+        assert root == os.path.abspath('/tmp')
     monkeypatch.setattr(setuptools_scm, 'version_from_scm', assert_root_tmp)
     setuptools_scm.get_version(root='/tmp')
 


### PR DESCRIPTION
* for the above environment must be byte strings - not unicode
* fix test Windows - /tmp is not an absolute path on Windows.